### PR TITLE
fix: P/V is parity for AND/OR/XOR/TEST instructions

### DIFF
--- a/chapter-instr-close.tex
+++ b/chapter-instr-close.tex
@@ -190,7 +190,7 @@ Where possible, multiple variants of same instruction are grouped together and w
             {\tt 1} & {\tt 1} & {\tt 1} \\
         \end{tabular}
 
-        \begin{DetailEffects}[v]
+        \begin{DetailEffects}[p]
             \FlagsANDr
         \end{DetailEffects}
 
@@ -1567,7 +1567,7 @@ Where possible, multiple variants of same instruction are grouped together and w
             {\tt 1} & {\tt 1} & {\tt 1} \\
         \end{tabular}
 
-        \begin{DetailEffects}[v]
+        \begin{DetailEffects}[p]
             \FlagsORr
         \end{DetailEffects}
 				

--- a/chapter-instr-close.tex
+++ b/chapter-instr-close.tex
@@ -2832,7 +2832,7 @@ Where possible, multiple variants of same instruction are grouped together and w
 
         Similar to {\tt CP} (page \pageref{DetailRefCP}), but performs an {\tt AND} instead of a subtraction.
 
-        \begin{DetailEffects}[v]
+        \begin{DetailEffects}[p]
             \FlagsTESTn
         \end{DetailEffects}
 						

--- a/instructions.tex
+++ b/instructions.tex
@@ -760,7 +760,7 @@
 \newcommand{\FlagsADDrrnn}[1][\FlagsNoEffect]{\Flags[#1]{\FN}{\FN}{\FN}{\FN}{\FN}{\FN}}
 \newcommand{\FlagsADCr}[1][]{\Flags[#1]{\FS}{\FS}{\FS}{\FlagsFPV}{0}{\FS}}
 \newcommand{\FlagsADCrr}[1][]{\Flags[#1]{\FS\FlagsSee{1}}{\FS\FlagsSee{1}}{\FS\FlagsSee{2}}{\FlagsFPV\FlagsSee{1}}{0}{\FS\FlagsSee{1}}}
-\newcommand{\FlagsANDr}[1][]{\Flags[#1]{\FS}{\FS}{1}{\FlagsFPV}{0}{0}}
+\newcommand{\FlagsANDr}[1][]{\Flags[#1]{\FS}{\FS}{1}{\FlagsFPP}{0}{0}}
 \newcommand{\FlagsBITr}[1][]{\Flags[#1]{\FU\FlagsSee{1}}{\FS}{1}{\FU\FlagsSee{1}}{0}{\FN}}
 \newcommand{\FlagsBSLA}[1][\FlagsNoEffect]{\Flags[#1]{\FN}{\FN}{\FN}{\FN}{\FN}{\FN}}
 \newcommand{\FlagsBSRA}[1][\FlagsNoEffect]{\Flags[#1]{\FN}{\FN}{\FN}{\FN}{\FN}{\FN}}
@@ -821,7 +821,7 @@
 \newcommand{\FlagsNEXTREGna}[1][\FlagsNoEffect]{\Flags[#1]{\FN}{\FN}{\FN}{\FN}{\FN}{\FN}}
 \newcommand{\FlagsNEXTREGnn}[1][\FlagsNoEffect]{\Flags[#1]{\FN}{\FN}{\FN}{\FN}{\FN}{\FN}}
 \newcommand{\FlagsNOP}[1][\FlagsNoEffect]{\Flags[#1]{\FN}{\FN}{\FN}{\FN}{\FN}{\FN}}
-\newcommand{\FlagsORr}[1][]{\Flags[#1]{\FS}{\FS}{0}{\FlagsFPV}{0}{0}}
+\newcommand{\FlagsORr}[1][]{\Flags[#1]{\FS}{\FS}{0}{\FlagsFPP}{0}{0}}
 \newcommand{\FlagsOUTna}[1][\FlagsNoEffect]{\Flags[#1]{\FN}{\FN}{\FN}{\FN}{\FN}{\FN}}
 \newcommand{\FlagsOUTcr}[1][\FlagsNoEffect]{\Flags[#1]{\FN}{\FN}{\FN}{\FN}{\FN}{\FN}}
 \newcommand{\FlagsOUTc}[1][\FlagsNoEffect]{\Flags[#1]{\FN}{\FN}{\FN}{\FN}{\FN}{\FN}}
@@ -863,5 +863,5 @@
 \newcommand{\FlagsSRLr}[1][]{\Flags[#1]{\FS}{\FS}{0}{\FlagsFPP}{0}{\FS}}
 \newcommand{\FlagsSUBr}[1][]{\Flags[#1]{\FS}{\FS}{\FS}{\FlagsFPV}{1}{\FS}}
 \newcommand{\FlagsSWAPNIB}[1][\FlagsNoEffect]{\Flags[#1]{\FN}{\FN}{\FN}{\FN}{\FN}{\FN}}
-\newcommand{\FlagsTESTn}[1][]{\Flags[#1]{\FS}{\FS}{\FS}{\FlagsFPV}{\FU}{\FS}}
+\newcommand{\FlagsTESTn}[1][]{\Flags[#1]{\FS}{\FS}{\FS}{\FlagsFPP}{\FU}{\FS}}
 \newcommand{\FlagsXORr}[1][]{\Flags[#1]{\FS}{\FS}{0}{\FlagsFPP}{0}{0}}


### PR DESCRIPTION
I didn't test-build the TEX, just replaced it in text editor, so please verify it's correct, ty.